### PR TITLE
UndertowJaxrsServer: Exposing the ability to add prefix paths to the server root path handler

### DIFF
--- a/server-adapters/resteasy-undertow/src/main/java/org/jboss/resteasy/plugins/server/undertow/UndertowJaxrsServer.java
+++ b/server-adapters/resteasy-undertow/src/main/java/org/jboss/resteasy/plugins/server/undertow/UndertowJaxrsServer.java
@@ -116,8 +116,19 @@ public class UndertowJaxrsServer
       if (appPath != null) path = appPath.value();
       return undertowDeployment(application, path);
    }
-
-
+   
+   /**
+    * Maps a path prefix to a resource handler to allow serving resources other than the JAX-RS endpoints.
+    * For example, this can be used for serving static resources like web pages or API documentation that might 
+    * be deployed with the REST application server. 
+    * 
+    * @param path 
+    * @param handler
+    */
+   public void addResourcePrefixPath(String path, ResourceHandler handler) 
+   {
+      root.addPrefixPath(path, handler);
+   }
 
    /**
     * Creates a web deployment under "/"

--- a/server-adapters/resteasy-undertow/src/main/java/org/jboss/resteasy/plugins/server/undertow/UndertowJaxrsServer.java
+++ b/server-adapters/resteasy-undertow/src/main/java/org/jboss/resteasy/plugins/server/undertow/UndertowJaxrsServer.java
@@ -2,6 +2,7 @@ package org.jboss.resteasy.plugins.server.undertow;
 
 import io.undertow.Undertow;
 import io.undertow.server.handlers.PathHandler;
+import io.undertow.server.handlers.resource.ResourceHandler;
 import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.DeploymentManager;
 import io.undertow.servlet.api.ServletContainer;


### PR DESCRIPTION
Undertow allows adding a variety of paths, but the default behavior in the current UndertowJaxrsServer automatically registers a root handler and implicitly adds the JAX-RS defined paths to it, disallowing manually adding other paths. 

The new method in this commit allows the manual addition of other paths such as for serving static resources (e.g. web pages, API documentation) alongside the REST endpoints. 

Inspired by a discussion I found when trying to find a solution to this problem: http://lists.jboss.org/pipermail/undertow-dev/2014-February/000680.html
